### PR TITLE
Update config.flysystem-minio.yaml

### DIFF
--- a/config.flysystem-minio.yaml
+++ b/config.flysystem-minio.yaml
@@ -1,4 +1,4 @@
-# ddev-generated
+#ddev-generated
 hooks:
   post-start:
     - exec-host: "ddev create-buckets"


### PR DESCRIPTION
Tried to remove, got:

```
Unwilling to remove '/Users/adam/repos/dgi-starter/.ddev/minio-flysystem/flysystem_config.json' because it does not have #ddev-generated in it: signature was not found in file /Users/adam/repos/dgi-starter/.ddev/minio-flysystem/flysystem_config.json; you can manually delete it if it is safe to delete.
Unwilling to remove '/Users/adam/repos/dgi-starter/.ddev/config.flysystem-minio.yaml' because it does not have #ddev-generated in it: signature was not found in file /Users/adam/repos/dgi-starter/.ddev/config.flysystem-minio.yaml; you can manually delete it if it is safe to delete.
```

The `.json` one, not much we can do for it; however, thinking the spacing there should be fixed in the `config.flysystem-minio.yaml` bit.